### PR TITLE
Fixed struct format to prevent lagging cursor and future bug

### DIFF
--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -104,7 +104,7 @@ def read_tablet(args):
     stdout = open_eventfile(args)
 
     while True:
-        _, _, _, _, e_type, e_code, e_value = struct.unpack('4IHHI', stdout.read(24))
+        _, _, e_type, e_code, e_value = struct.unpack('2IHHi', stdout.read(16))
 
         if e_type == EV_ABS:
 


### PR DESCRIPTION
Addressing [this reddit post](https://www.reddit.com/r/RemarkableTablet/comments/atsm27/update_to_using_the_tablet_as_a_mouse_the_process/eh5x7qa).

# Explaining the struct

The evdev struct used in the reMarkable linux kernel can be found [here](https://github.com/reMarkable/linux/blob/b82cb2adc32411c98ffc0db86cdd12858c8b39df/include/uapi/linux/input.h#L24):
``` c
struct input_event {
	struct timeval time;
	__u16 type;
	__u16 code;
	__s32 value;
};
```
(The timeval field can be found [here](https://github.com/reMarkable/linux/blob/b82cb2adc32411c98ffc0db86cdd12858c8b39df/include/uapi/linux/time.h#L15).)

The timeval struct consists presumable out of 2 32bit unsigned integers.

To confirm the sizes, I wrote a small c program that outputs all the sizes:
``` c
#include <stdio.h>
#include <sys/time.h> // For timeval
#include <stdint.h>

struct rm_input_event {
        struct timeval time;
        uint16_t type;
        uint16_t code;
        int32_t value;
};

int main() {
    struct rm_input_event myStruct;

    printf("Size of whole struct: %d bytes\n", sizeof(myStruct));
    printf("Size of time: %d bytes\n", sizeof(myStruct.time));
    printf("Size of type: %d bytes\n", sizeof(myStruct.type));
    printf("Size of code: %d bytes\n", sizeof(myStruct.code));
    printf("Size of value: %d bytes\n", sizeof(myStruct.value));

    return 0;
}
```

Compiled and executed on the reMarkable it yields:
```
Size of whole struct: 16 bytes
Size of time: 8 bytes
Size of type: 2 bytes
Size of code: 2 bytes
Size of value: 4 bytes
```

As you can see, the *time*-field is 8 bytes big (= 64 bit).

# The problem

https://github.com/Evidlo/remarkable_mouse/blob/1daaa1e3fe4d70a2b19a5a662a0688f317173e6b/remarkable_mouse/remarkable_mouse.py#L107

When deconstructing the data you took 4 32 bit unsigned integers. So that amounts to 128 bit which is too much. The rest of the data will be garbage and thanks to checking *ev_type* and *ev_code* ingored/skipped till those values happen to be in the right spot.

Changing `4I` to `2I` and the total size from 24 bytes to 16 bytes will fix that problem and result in smooth movement, since you now process all input events.

---
**Side note**

I also changed the format of *ev_value* from *I* (32 bit unsigned int) to *i* (32 bit singed int).

When using the tilt values you will stumble upon this, since they use negative values, depending on the direction the pen is tilted (and 0 beeing no tilt at all).
Example: `XPos:  4753 | YPos:  7405 | XTilt:   100 | YTilt: -3600 | Distance:   0 | Pressure: 1896`

It also matches the corresponding field in the struct which is *int32_t* (originally *__s32*) which is signed.