### PR TITLE
feat: option to use ssh agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install remarkable-mouse
 remouse
 ```
 
-By default, `10.11.99.1` is used as the address.  Seems to work pretty well wirelessly, too.
+By default, `10.11.99.1` is used as the address. Seems to work pretty well wirelessly, too. By default ssh-agent is used to authenticate if it is available, otherwise you are asked for your password.
 
 # Examples
 


### PR DESCRIPTION
Add use ssh agent option for when the available key would otherwise require a password each time.

Happy to change this to meet your preferences.