### PR TITLE
chore: switch device id number to hex for easier matching with header…

### DIFF
--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -25,8 +25,8 @@ def create_local_device():
     # Set device properties to emulate those of Wacom tablets
     device.name = 'reMarkable tablet'
     device.id = {
-        'bustype': 24,
-        'vendor': 1386,
+        'bustype': 0x18, # i2c
+        'vendor': 0x056a, # wacom
         'product': 0,
         'version': 54
     }


### PR DESCRIPTION
Working on getting libwacom to recognize this and treat it as a first class citizen.
Also working on a udev rule to automatically run remarkable mouse.

Switching these to hex helped with lookup in headers and such and reportings by the different command line tools.

After adding a libwacom database entry for this, for example, it reports it as: 

`DeviceMatch=i2c:056a:0000;`

