### PR TITLE
Add monitor switch & right/middle mouse modifiers

### DIFF
--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -65,6 +65,9 @@ def read_tablet(args, remote_device):
     from pynput.mouse import Button, Controller
 
     lifted = True
+    Rlifted = True
+    Mlifted = True
+
     new_x = new_y = False
 
     mouse = Controller()


### PR DESCRIPTION
I love this script! Too bad pressure & angle doesnt work in windows..

Anyway, I wanted to use it not only for drawing but incorporated in general computer use too. I am in no way a programmer but can follow very roughly the logic from my matlab days and I can google - so I got inspired to see if I could do it mself. As it is now it works, but since I know nothing of best practices or best libraries to use it can probably use the approach of an actual programmer. Now uses 'keyboard' because it's the first I found to work and couldn't figure out how to use the pynput listen in the loop.
Ctrl+click = right click
Shift+click = middle click (and scrolling in most applications)

Alt + 1/2/3 switches monitor during operation - this only works if the pen is in 'lifted' state, not when it is totally off. Works well enough for me but can be definately more elegant

I'd love to see a tray button with quit (and  pause?), because I run with pythonw in the background but have to kill the process to quit.
Would also be nice if it can somehow reconnect if the reMarkable went to sleep and you turn it on again.
But hey, my first python lines written ever!