### PR TITLE
Rely on MapToOuput

### DIFF
--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -99,10 +99,10 @@ def remap(wacom_width, wacom_height, monitor_width,
         scale = wacom_height
 
     ratio = wacom_height / monitor_height
-    screen_ratio = monitor_width - scale / ratio
+    screen_ratio = monitor_width * ratio
     
-    min_scale = round(ratio * (0 - screen_ratio / 2))
-    max_scale = round(ratio * (monitor_width - screen_ratio / 2))
+    min_scale = round(scale - screen_ratio / 2))
+    max_scale = round(screen_ratio - min_scale)
 
     min_x, max_x = min_scale, max_scale
     min_y, max_y = 0, wacom_height

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -106,8 +106,8 @@ def remap(wacom_width, wacom_height, monitor_width,
     ratio = wacom_height / monitor_height
     screen_ratio = monitor_width - scale / ratio
     
-    min_scale = ratio * (0 - screen_ratio / 2)
-    max_scale = ratio * (monitor_width - screen_ratio / 2)
+    min_scale = round(ratio * (0 - screen_ratio / 2))
+    max_scale = round(ratio * (monitor_width - screen_ratio / 2))
 
     min_x = min_scale
     max_x = max_scale
@@ -177,6 +177,9 @@ def pipe_device(args, remote_device, local_device):
             {} {} {} {}'.format(*coordinates),
             capture_output=True,
             shell=True
+        )
+        if result.returncode != 0:
+            log.warning("Error setting fit: %s", result.stderr)
         
     import libevdev
 

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -93,11 +93,6 @@ def create_local_device():
 # remap screen coordinates to wacom coordinates
 def remap(wacom_width, wacom_height, monitor_width,
           monitor_height, orientation=None):
-
-    min_x = 0
-    min_y = 0
-    max_x = 0
-    max_y = 0
     
     scale = wacom_width
     if orientation in ('top', 'bottom'):
@@ -109,22 +104,14 @@ def remap(wacom_width, wacom_height, monitor_width,
     min_scale = round(ratio * (0 - screen_ratio / 2))
     max_scale = round(ratio * (monitor_width - screen_ratio / 2))
 
-    min_x = min_scale
-    max_x = max_scale
-    max_y = wacom_height
+    min_x, max_x = min_scale, max_scale
+    min_y, max_y = 0, wacom_height
     
     if orientation in ('top', 'bottom'):
-        min_x = 0
-        min_y = min_scale
-        max_x = wacom_width
-        max_y = max_scale
+        min_x, max_x = 0, wacom_width
+        min_y, max_y = min_scale, max_scale
     
-    return (
-        min_x,
-        min_y,
-        max_x,
-        max_y
-    )
+    return (min_x, min_y, max_x, max_y)
 
 def pipe_device(args, remote_device, local_device):
     """


### PR DESCRIPTION
This PR removes the remapping code as `xinput --maptooutput` is meant to do the same thing (just better), and the remapping is now both redundant and has been causing (at least) me margin issues.