### PR TITLE
Disable unsupported SHA-2 pubkey algorithms

### DIFF
--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -73,7 +73,8 @@ def open_rm_inputs(*, address, key, password):
         username='root',
         password=password,
         pkey=pkey,
-        look_for_keys=False
+        look_for_keys=False,
+        disabled_algorithms=dict(pubkeys=["rsa-sha2-512", "rsa-sha2-256"])
     )
 
     session = client.get_transport().open_session()


### PR DESCRIPTION
As documented in https://github.com/paramiko/paramiko/issues/1961 there is an incompatibility between Paramiko 2.9+ and dropbear (the SSH server used on Remarkable) when negotiating the pubkey algorithm. This fixes the issue by disabling SHA-2 algorithms, causing Paramiko to offer a SHA-1 algorithm which Dropbear will accept.

Without this change, the connection fails with a generic error when Paramiko 2.9+ is used:

```
Traceback (most recent call last):
  File "/usr/local/bin/remouse", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/remarkable_mouse/remarkable_mouse.py", line 131, in main
    rm_inputs = open_rm_inputs(
  File "/usr/local/lib/python3.10/site-packages/remarkable_mouse/remarkable_mouse.py", line 71, in open_rm_inputs
    client.connect(
  File "/usr/local/lib/python3.10/site-packages/paramiko/client.py", line 435, in connect
    self._auth(
  File "/usr/local/lib/python3.10/site-packages/paramiko/client.py", line 766, in _auth
    raise saved_exception
  File "/usr/local/lib/python3.10/site-packages/paramiko/client.py", line 666, in _auth
    self._transport.auth_publickey(username, pkey)
  File "/usr/local/lib/python3.10/site-packages/paramiko/transport.py", line 1634, in auth_publickey
    return self.auth_handler.wait_for_response(my_event)
  File "/usr/local/lib/python3.10/site-packages/paramiko/auth_handler.py", line 258, in wait_for_response
    raise e
paramiko.ssh_exception.AuthenticationException: Authentication failed.
```