### PR TITLE
evdev: Fix max values for MT evdev events and correct resolution

### DIFF
--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -46,8 +46,8 @@ def create_local_device():
 
     inputs = (
         # touch inputs
-        (libevdev.EV_ABS.ABS_MT_POSITION_X,  0,    20967,   2531),
-        (libevdev.EV_ABS.ABS_MT_POSITION_Y,  0,    15725,  2531),
+        (libevdev.EV_ABS.ABS_MT_POSITION_X,  0,    20967,   100),
+        (libevdev.EV_ABS.ABS_MT_POSITION_Y,  0,    15725,  100),
         (libevdev.EV_ABS.ABS_MT_PRESSURE,    0,    4095,   None),
         (libevdev.EV_ABS.ABS_MT_TOUCH_MAJOR, 0,    255,   None),
         (libevdev.EV_ABS.ABS_MT_TOUCH_MINOR, 0,    255,   None),
@@ -57,8 +57,8 @@ def create_local_device():
         (libevdev.EV_ABS.ABS_MT_TRACKING_ID, 0,    65535, None),
 
         # pen inputs
-        (libevdev.EV_ABS.ABS_X,        0,     20967,  2531), # cyttps5_mt driver
-        (libevdev.EV_ABS.ABS_Y,        0,     15725,  2531), # cyttsp5_mt
+        (libevdev.EV_ABS.ABS_X,        0,     20967,  100), # cyttps5_mt driver
+        (libevdev.EV_ABS.ABS_Y,        0,     15725,  100), # cyttsp5_mt
         (libevdev.EV_ABS.ABS_PRESSURE, 0,     4095,   None),
         (libevdev.EV_ABS.ABS_DISTANCE, 0,     255,    None),
         (libevdev.EV_ABS.ABS_TILT_X,   -9000, 9000,   None),

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -46,9 +46,9 @@ def create_local_device():
 
     inputs = (
         # touch inputs
-        (libevdev.EV_ABS.ABS_MT_POSITION_X,  0,    767,   2531),
-        (libevdev.EV_ABS.ABS_MT_POSITION_Y,  0,    1023,  2531),
-        (libevdev.EV_ABS.ABS_MT_PRESSURE,    0,    255,   None),
+        (libevdev.EV_ABS.ABS_MT_POSITION_X,  0,    20967,   2531),
+        (libevdev.EV_ABS.ABS_MT_POSITION_Y,  0,    15725,  2531),
+        (libevdev.EV_ABS.ABS_MT_PRESSURE,    0,    4095,   None),
         (libevdev.EV_ABS.ABS_MT_TOUCH_MAJOR, 0,    255,   None),
         (libevdev.EV_ABS.ABS_MT_TOUCH_MINOR, 0,    255,   None),
         (libevdev.EV_ABS.ABS_MT_ORIENTATION, -127, 127,   None),


### PR DESCRIPTION
This is required to make the evdev module work on my remarkable2

The resolution changes are not strictly necessary but they make the device show up with the correct size in `libinput list-devices`.