### PR TITLE
evdev: fix aspect ratio when using fit/fill

### DIFF
--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -118,15 +118,20 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
             if codes[e_type][e_code] == 'ABS_Y':
                 y = e_value
 
+            # map to screen coordinates so that region/monitor/orientation options are applied
             mapped_x, mapped_y = remap(
                 x, y,
                 wacom_max_x, wacom_max_y,
-                wacom_max_x * (monitor.width / tot_width), wacom_max_y * (monitor.height / tot_height),
+                monitor.width, monitor.height,
                 mode, orientation
             )
 
-            mapped_x += wacom_max_x * (monitor.x / tot_width)
-            mapped_y += wacom_max_y * (monitor.y / tot_height)
+            mapped_x += monitor.x
+            mapped_y += monitor.y
+
+            # map back to wacom coordinates to reinsert into event
+            mapped_x = mapped_x * wacom_max_x / tot_width
+            mapped_y = mapped_y * wacom_max_y / tot_height
 
             # reinsert modified values into evdev event
             if codes[e_type][e_code] == 'ABS_X':


### PR DESCRIPTION
The code before this commit called remap by translating output width
into wacom coordinates, so that remap returns wacom coordinates.
But this does not work correctly with the aspect ratio calculation that
remap is doing: in wacom coordinates, 1 unit in x direction may not be
the same length as 1 unit in y direction (since wacom coordinates get
stretched to the full screen by the input driver).

This commit fixes the issue by calling remap with proper output widths,
and then translating the result back into wacom coordinates for
rewriting the event.