### PR TITLE
fix: password prompt for private key

### DIFF
--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -53,8 +53,6 @@ def open_rm_inputs(*, address, key, password):
         for key_type in [paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey]:
             try:
                 pkey = key_type.from_private_key_file(os.path.expanduser(key))
-            except paramiko.ssh_exception.SSHException:
-                continue
             except paramiko.ssh_exception.PasswordRequiredException:
                 passphrase = getpass(
                     "Enter passphrase for key '{}': ".format(os.path.expanduser(key))
@@ -63,6 +61,8 @@ def open_rm_inputs(*, address, key, password):
                     os.path.expanduser(key), password=passphrase
                 )
                 break
+            except paramiko.ssh_exception.SSHException:
+                continue
         return pkey
 
     # use provided key


### PR DESCRIPTION
use_key function was catching `paramiko.ssh_exception.SSHException` before `paramiko.ssh_exception.PasswordRequiredException`. However, since `SSHException` is a superclass of `PasswordRequiredException`, this latter one was never catched, and so the password prompt was never displayed.