### PR TITLE
Add a hotkey to pause listening to new movements

### DIFF
--- a/remarkable_mouse/common.py
+++ b/remarkable_mouse/common.py
@@ -28,7 +28,7 @@ def get_monitor(region, monitor_num, orientation):
 
     # compute size of box encompassing all screens
     max_x, max_y = 0, 0
-    if(sys.platform == 'darwin')
+    if(sys.platform == 'darwin'):
     	log.debug(f"Handling MacOS monitors")
     	monitors = get_monitors(Enumerator.OSX)
     else:

--- a/remarkable_mouse/common.py
+++ b/remarkable_mouse/common.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from screeninfo import get_monitors, Monitor
+from screeninfo import get_monitors, Monitor, Enumerator
 
 from .codes import codes, types
 
@@ -28,7 +28,12 @@ def get_monitor(region, monitor_num, orientation):
 
     # compute size of box encompassing all screens
     max_x, max_y = 0, 0
-    for m in get_monitors():
+    if(sys.platform == 'darwin')
+    	log.debug(f"Handling MacOS monitors")
+    	monitors = get_monitors(Enumerator.OSX)
+    else:
+    	monitors = get_monitors()
+    for m in monitors:
         x = m.x + m.width
         y = m.y + m.height
         max_x = max(x, max_x)
@@ -41,7 +46,7 @@ def get_monitor(region, monitor_num, orientation):
             name="Fake monitor from region selection"
         )
     else:
-        monitor = get_monitors()[monitor_num]
+        monitor = monitors[monitor_num]
 
     log.debug(f"Chose monitor: {monitor}")
     log.debug(f"Screen size: ({max_x}, {max_y})")

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -76,7 +76,7 @@ def create_local_device():
     return device.create_uinput_device()
 
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,halt_hotkey):
     """Pipe rM evdev events to local device
 
     Args:
@@ -100,7 +100,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
     # loop inputs forever
     # for input_name, stream in cycle(rm_inputs.items()):
     stream = rm_inputs['pen']
-    while True:
+    while(not keyboard.is_pressed(halt_hotkey)):
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -101,7 +101,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     # loop inputs forever
     # for input_name, stream in cycle(rm_inputs.items()):
     stream = rm_inputs['pen']
-    while(not keyboard.is_pressed(halt_hotkey)):
+    while True:
+    	if(keyboard.is_pressed(halt_hotkey)):
+    		continue
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -6,6 +6,7 @@ import time
 from itertools import cycle
 from socket import timeout as TimeoutError
 import libevdev
+import keyboard
 
 from .codes import codes, types
 from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -102,50 +102,49 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     # for input_name, stream in cycle(rm_inputs.items()):
     stream = rm_inputs['pen']
     while True:
-    	if(keyboard.is_pressed(halt_hotkey)):
-    		continue
-        try:
-            data = stream.read(16)
-        except TimeoutError:
-            continue
+        if(not keyboard.is_pressed(halt_hotkey)):
+            try:
+                data = stream.read(16)
+            except TimeoutError:
+                continue
 
-        e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
+            e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
 
-        # intercept EV_ABS events and modify coordinates
-        if types[e_type] == 'EV_ABS':
-            # handle x direction
-            if codes[e_type][e_code] == 'ABS_X':
-                x = e_value
+            # intercept EV_ABS events and modify coordinates
+            if types[e_type] == 'EV_ABS':
+                # handle x direction
+                if codes[e_type][e_code] == 'ABS_X':
+                    x = e_value
 
-            # handle y direction
-            if codes[e_type][e_code] == 'ABS_Y':
-                y = e_value
+                # handle y direction
+                if codes[e_type][e_code] == 'ABS_Y':
+                    y = e_value
 
-            # map to screen coordinates so that region/monitor/orientation options are applied
-            mapped_x, mapped_y = remap(
-                x, y,
-                wacom_max_x, wacom_max_y,
-                monitor.width, monitor.height,
-                mode, orientation
-            )
+                # map to screen coordinates so that region/monitor/orientation options are applied
+                mapped_x, mapped_y = remap(
+                    x, y,
+                    wacom_max_x, wacom_max_y,
+                    monitor.width, monitor.height,
+                    mode, orientation
+                )
 
-            mapped_x += monitor.x
-            mapped_y += monitor.y
+                mapped_x += monitor.x
+                mapped_y += monitor.y
 
-            # map back to wacom coordinates to reinsert into event
-            mapped_x = mapped_x * wacom_max_x / tot_width
-            mapped_y = mapped_y * wacom_max_y / tot_height
+                # map back to wacom coordinates to reinsert into event
+                mapped_x = mapped_x * wacom_max_x / tot_width
+                mapped_y = mapped_y * wacom_max_y / tot_height
 
-            # reinsert modified values into evdev event
-            if codes[e_type][e_code] == 'ABS_X':
-                e_value = int(mapped_x)
-            if codes[e_type][e_code] == 'ABS_Y':
-                e_value = int(mapped_y)
+                # reinsert modified values into evdev event
+                if codes[e_type][e_code] == 'ABS_X':
+                    e_value = int(mapped_x)
+                if codes[e_type][e_code] == 'ABS_Y':
+                    e_value = int(mapped_y)
 
-        # pass events directly to libevdev
-        e_bit = libevdev.evbit(e_type, e_code)
-        e = libevdev.InputEvent(e_bit, value=e_value)
-        local_device.send_events([e])
+            # pass events directly to libevdev
+            e_bit = libevdev.evbit(e_type, e_code)
+            e = libevdev.InputEvent(e_bit, value=e_value)
+            local_device.send_events([e])
 
-        if log.level == logging.DEBUG:
-            log_event(e_time, e_millis, e_type, e_code, e_value)
+            if log.level == logging.DEBUG:
+                log_event(e_time, e_millis, e_type, e_code, e_value)

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -38,7 +38,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     x = y = 0
 
     stream = rm_inputs['pen']
-    while(not keyboard.is_pressed(halt_hotkey)):
+    while True:
+        if(keyboard.is_pressed(halt_hotkey)):
+     	   continue
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -15,7 +15,7 @@ log = logging.getLogger('remouse')
 # finger_width = 767
 # finger_height = 1023
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,halt_hotkey):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, halt_hotkey):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -39,29 +39,29 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
 
     stream = rm_inputs['pen']
     while True:
-        if(not keyboard.is_pressed(halt_hotkey)):
-            try:
-                data = stream.read(16)
-            except TimeoutError:
-                continue
+        try:
+            data = stream.read(16)
+        except TimeoutError:
+            continue
 
-            e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
+        e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
 
-            # handle x direction
-            if codes[e_type][e_code] == 'ABS_X':
-                x = e_value
+        # handle x direction
+        if codes[e_type][e_code] == 'ABS_X':
+            x = e_value
 
-            # handle y direction
-            if codes[e_type][e_code] == 'ABS_Y':
-                y = e_value
+        # handle y direction
+        if codes[e_type][e_code] == 'ABS_Y':
+            y = e_value
 
-            # handle draw
-            if codes[e_type][e_code] == 'BTN_TOUCH':
-                if e_value == 1:
-                    mouse.press(Button.left)
-                else:
-                    mouse.release(Button.left)
+        # handle draw
+        if codes[e_type][e_code] == 'BTN_TOUCH':
+            if e_value == 1:
+                mouse.press(Button.left)
+            else:
+                mouse.release(Button.left)
 
+        if(not halt_hotkey or not keyboard.is_pressed(halt_hotkey)):
             if codes[e_type][e_code] == 'SYN_REPORT':
                 mapped_x, mapped_y = remap(
                     x, y,
@@ -76,3 +76,5 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
 
             if log.level == logging.DEBUG:
                 log_event(e_time, e_millis, e_type, e_code, e_value)
+        else:
+            log.debug(f"listening of event stopped by hotkey")

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -14,7 +14,7 @@ log = logging.getLogger('remouse')
 # finger_width = 767
 # finger_height = 1023
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,halt_hotkey):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -37,7 +37,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
     x = y = 0
 
     stream = rm_inputs['pen']
-    while True:
+    while(not keyboard.is_pressed(halt_hotkey)):
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -1,5 +1,6 @@
 import logging
 import struct
+import keyboard
 from screeninfo import get_monitors
 
 # from .codes import EV_SYN, EV_ABS, ABS_X, ABS_Y, BTN_TOUCH

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -39,41 +39,40 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
 
     stream = rm_inputs['pen']
     while True:
-        if(keyboard.is_pressed(halt_hotkey)):
-     	   continue
-        try:
-            data = stream.read(16)
-        except TimeoutError:
-            continue
+        if(not keyboard.is_pressed(halt_hotkey)):
+            try:
+                data = stream.read(16)
+            except TimeoutError:
+                continue
 
-        e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
+            e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
 
-        # handle x direction
-        if codes[e_type][e_code] == 'ABS_X':
-            x = e_value
+            # handle x direction
+            if codes[e_type][e_code] == 'ABS_X':
+                x = e_value
 
-        # handle y direction
-        if codes[e_type][e_code] == 'ABS_Y':
-            y = e_value
+            # handle y direction
+            if codes[e_type][e_code] == 'ABS_Y':
+                y = e_value
 
-        # handle draw
-        if codes[e_type][e_code] == 'BTN_TOUCH':
-            if e_value == 1:
-                mouse.press(Button.left)
-            else:
-                mouse.release(Button.left)
+            # handle draw
+            if codes[e_type][e_code] == 'BTN_TOUCH':
+                if e_value == 1:
+                    mouse.press(Button.left)
+                else:
+                    mouse.release(Button.left)
 
-        if codes[e_type][e_code] == 'SYN_REPORT':
-            mapped_x, mapped_y = remap(
-                x, y,
-                wacom_max_x, wacom_max_y,
-                monitor.width, monitor.height,
-                mode, orientation,
-            )
-            mouse.move(
-                monitor.x + mapped_x - mouse.position[0],
-                monitor.y + mapped_y - mouse.position[1]
-            )
+            if codes[e_type][e_code] == 'SYN_REPORT':
+                mapped_x, mapped_y = remap(
+                    x, y,
+                    wacom_max_x, wacom_max_y,
+                    monitor.width, monitor.height,
+                    mode, orientation,
+                )
+                mouse.move(
+                    monitor.x + mapped_x - mouse.position[0],
+                    monitor.y + mapped_y - mouse.position[1]
+                )
 
-        if log.level == logging.DEBUG:
-            log_event(e_time, e_millis, e_type, e_code, e_value)
+            if log.level == logging.DEBUG:
+                log_event(e_time, e_millis, e_type, e_code, e_value)

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -141,6 +141,7 @@ def main():
         parser.add_argument('--region', action='store_true', default=False, help="Use a GUI to position the output area. Overrides --monitor")
         parser.add_argument('--threshold', metavar='THRESH', default=600, type=int, help="stylus pressure threshold (default 600)")
         parser.add_argument('--evdev', action='store_true', default=False, help="use evdev to support pen pressure (requires root, Linux only)")
+        parser.add_argument('--hotkey', default='F2', type=str, help="define shortcut to halt the listening of clicks. \nFor combinations, use format 'shift+s, space'\ndefault: 'F2'")
 
         args = parser.parse_args()
 
@@ -174,6 +175,7 @@ def main():
             region=args.region,
             threshold=args.threshold,
             mode=args.mode,
+            halt_hotkey=halt_hotkey
         )
 
     except PermissionError:

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -175,7 +175,7 @@ def main():
             region=args.region,
             threshold=args.threshold,
             mode=args.mode,
-            halt_hotkey=halt_hotkey
+            halt_hotkey=args.hotkey
         )
 
     except PermissionError:

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -141,7 +141,7 @@ def main():
         parser.add_argument('--region', action='store_true', default=False, help="Use a GUI to position the output area. Overrides --monitor")
         parser.add_argument('--threshold', metavar='THRESH', default=600, type=int, help="stylus pressure threshold (default 600)")
         parser.add_argument('--evdev', action='store_true', default=False, help="use evdev to support pen pressure (requires root, Linux only)")
-        parser.add_argument('--hotkey', default='F2', type=str, help="define shortcut to halt the listening of clicks. \nFor combinations, use format 'shift+s, space'\ndefault: 'F2'")
+        parser.add_argument('--hotkey', default='', type=str, help="define shortcut to halt the listening of clicks. \nFor combinations, use format 'shift+s, space'\ndefault: 'F2'")
 
         args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'paramiko',
         'libevdev',
         'pynput',
-        'screeninfo'
+        'screeninfo',
+        'keyboard'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
I implemented this feature so I could use the eraser when drawing. 

**What is going on** : 

 * I added a check in both  `read_tablet` functions tp pause the incoming events using a shortcut. 
 * The shortcut is fetched using [lib keyboard](https://github.com/boppreh/keyboard)
 * You can define your shortcut using `--hotkey` argument.
 * By default, no hotkey is defined
 * you can use all key codes [available here](https://github.com/boppreh/keyboard/blob/master/keyboard/_canonical_names.py)

**What could be improved**

 * **I implemented it, but did not test with evdev**
 * keyboard uses **a lot of imports**, there are probably lighter libs that could be used.
 * This branch also use a fix for MacOS I found in #82  and proposed in #83 