### PR TITLE
Pressure sensing on Windows, dynamic monitor selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ remouse
 By default, `10.11.99.1` is used as the address.  Find your password in the reMarkable's [settings menu](https://remarkablewiki.com/tech/ssh).  If you are on Linux using X11, you can use the `--evdev` option for pressure support.
 If you are on Windows, you can use the `--pen` option for pressure support.
 
-The monitor that the tablet will output to is dynamically changed to the one that the mouse is in. To output to only one monitor, 
-use the `--monitor` flag.
+The monitor that the tablet will output to is dynamically changed to the one that the mouse is in. To output to only one monitor, use the `--monitor` flag.
 
 To use the `--region` flag, you may need to install the `python3-tk` or `python3-tkinter` package with your package manager.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ remouse
 By default, `10.11.99.1` is used as the address.  Find your password in the reMarkable's [settings menu](https://remarkablewiki.com/tech/ssh).  If you are on Linux using X11, you can use the `--evdev` option for pressure support.
 If you are on Windows, you can use the `--pen` option for pressure support.
 
-The monitor that the tablet will output to is dynamically changed to the one that the mouse is in. To output to only one monitor, use the `--monitor` flag.
+The monitor that the tablet will output to is dynamically changed to the one that the mouse is in. To output to only one monitor, 
+use the `--monitor` flag.
 
 To use the `--region` flag, you may need to install the `python3-tk` or `python3-tkinter` package with your package manager.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# remarkable_mouse with pressure and tilt for Windows
+
+While using the excellent remarkable mouse from Evidlo I needed to have pressure sensitivity for Windows. I don't really know how to code but following the logic an through online searches came to a solution. It is probably not pretty, but it works and it also enables tilt in Windows by creating a virtual pen injection. Use the --pen flag to load this mode. Would be great of someone would take this, implement it correctly and create a tray tool out of it with some options (switch windows during usage for instance).
+
+You can download a zip of this repo and install with 'pip install path-to-zip'.
+
 # remarkable_mouse
 
 Use your reMarkable as a graphics tablet.

--- a/README.md
+++ b/README.md
@@ -64,5 +64,6 @@ optional arguments:
   --region              Use a GUI to position the output area. Overrides --monitor
   --threshold THRESH    stylus pressure threshold (default 600)
   --evdev               use evdev to support pen pressure (requires root, Linux only)
+  --pen                 use pen injection to support pen pressure (Windows only)
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ pip install remarkable-mouse
 remouse
 ```
 
-By default, `10.11.99.1` is used as the address.  Find your password in the reMarkable's [settings menu](https://remarkablewiki.com/tech/ssh).  If you are on Linux using X11, you can use the `--evdev` option for pressure support or you are on Windows, you can use the `--pen` option.
+By default, `10.11.99.1` is used as the address.  Find your password in the reMarkable's [settings menu](https://remarkablewiki.com/tech/ssh).  If you are on Linux using X11, you can use the `--evdev` option for pressure support.
+If you are on Windows, you can use the `--pen` option for pressure support.
 
 The monitor that the tablet will output to is dynamically changed to the one that the mouse is in. To output to only one monitor, use the `--monitor` flag.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# remarkable_mouse with pressure and tilt for Windows
-
-While using the excellent remarkable mouse from Evidlo I needed to have pressure sensitivity for Windows. I don't really know how to code but following the logic an through online searches came to a solution. It is probably not pretty, but it works and it also enables tilt in Windows by creating a virtual pen injection. Use the --pen flag to load this mode. Would be great of someone would take this, implement it correctly and create a tray tool out of it with some options (switch windows during usage for instance).
-
-You can download a zip of this repo and install with 'pip install path-to-zip'.
-
 # remarkable_mouse
 
 Use your reMarkable as a graphics tablet.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ pip install remarkable-mouse
 remouse
 ```
 
-By default, `10.11.99.1` is used as the address.  Find your password in the reMarkable's [settings menu](https://remarkablewiki.com/tech/ssh).  If you are on Linux using X11, you can use the `--evdev` option for pressure support.
+By default, `10.11.99.1` is used as the address.  Find your password in the reMarkable's [settings menu](https://remarkablewiki.com/tech/ssh).  If you are on Linux using X11, you can use the `--evdev` option for pressure support or you are on Windows, you can use the `--pen` option.
+
+The monitor that the tablet will output to is dynamically changed to the one that the mouse is in. To output to only one monitor, use the `--monitor` flag.
 
 To use the `--region` flag, you may need to install the `python3-tk` or `python3-tkinter` package with your package manager.
 
@@ -44,26 +46,26 @@ sudo --preserve-env=USER,PATH env remouse --evdev
 # Usage
 
 ```
-usage: remouse [-h] [--debug] [--key PATH] [--password PASSWORD] [--address ADDRESS] [--mode {fit,fill,stretch}] [--orientation {top,left,right,bottom}] [--monitor NUM] [--region] [--threshold THRESH]
-               [--evdev]
+usage: remouse [-h] [--debug] [--key PATH] [--password PASSWORD] [--address ADDRESS] [--mode {fit,fill,stretch}] [--orientation {top,left,right,bottom}] [--monitor NUM] [--region]
+               [--threshold THRESH] [--evdev] [--pen]
 
 use reMarkable tablet as a mouse input
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               enable debug messages
   --key PATH            ssh private key
   --password PASSWORD   ssh password
   --address ADDRESS     device address
   --mode {fit,fill,stretch}
-                        Scale setting. Fit (default): take up the entire tablet, but not necessarily the entire monitor. Fill: take up the entire monitor, but not necessarily the entire tablet. Stretch:
-                        take up both the entire tablet and monitor, but don't maintain aspect ratio.
+                        Scale setting. Fit (default): take up the entire tablet, but not necessarily the entire monitor. Fill: take up the entire monitor, but not necessarily the entire
+                        tablet. Stretch: take up both the entire tablet and monitor, but don't maintain aspect ratio.
   --orientation {top,left,right,bottom}
                         position of tablet buttons
-  --monitor NUM         monitor to output to
-  --region              Use a GUI to position the output area. Overrides --monitor
+  --monitor NUM         override automatic monitor selection
+  --region              Use a GUI to position the output area. Overrides --monitor and automatic monitor selection
   --threshold THRESH    stylus pressure threshold (default 600)
   --evdev               use evdev to support pen pressure (requires root, Linux only)
-  --pen                 use pen injection to support pen pressure (Windows only)
+  --pen                 use pen input to support pen pressure in windows
 ```
 

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,0 +1,5 @@
+home = C:\Users\Guest1\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0
+include-system-site-packages = false
+version = 3.12.3
+executable = C:\Users\Guest1\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\python.exe
+command = C:\Users\Guest1\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\python.exe -m venv E:\Programming Projects\remarkable_mouse_winpress

--- a/remarkable_mouse/common.py
+++ b/remarkable_mouse/common.py
@@ -30,7 +30,7 @@ def get_current_monitor_num():
     return 0
 
 
-def get_monitor(region, monitor_num, orientation, auto_adjust):
+def get_monitor(region, monitor_num, orientation):
     """ Get info of where we want to map the tablet to
 
     Args:

--- a/remarkable_mouse/common.py
+++ b/remarkable_mouse/common.py
@@ -25,6 +25,7 @@ def get_current_monitor_num():
 
     for i, monitor in enumerate(get_monitors()):
         if mouse_x >= monitor.x and mouse_x < monitor.x + monitor.width and mouse_y >= monitor.y and mouse_y < monitor.y + monitor.height:
+            print(i)
             return i
     return 0
 

--- a/remarkable_mouse/common.py
+++ b/remarkable_mouse/common.py
@@ -24,8 +24,8 @@ def get_current_monitor_num():
     mouse_y = mouse.position[1]
 
     for i, monitor in enumerate(get_monitors()):
-        if mouse_x >= monitor.x and mouse_x < monitor.x + monitor.width and mouse_y >= monitor.y and mouse_y < monitor.y + monitor.height:
-            print(i)
+        if (mouse_x >= monitor.x and mouse_x < monitor.x + monitor.width and 
+                mouse_y >= monitor.y and mouse_y < monitor.y + monitor.height): 
             return i
     return 0
 

--- a/remarkable_mouse/common.py
+++ b/remarkable_mouse/common.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 from screeninfo import get_monitors, Monitor
-
 from .codes import codes, types
 
 logging.basicConfig(format='%(message)s')
@@ -12,7 +11,25 @@ log = logging.getLogger('remouse')
 wacom_max_y = 15725
 wacom_max_x = 20967
 
-def get_monitor(region, monitor_num, orientation):
+def get_current_monitor_num():
+    """ Get monitor number that the mouse is currently on
+
+    Returns:
+        int: monitor number that mouse is currently on, or 0 if couldn't pick one
+    """
+    from pynput.mouse import Controller
+
+    mouse = Controller()
+    mouse_x = mouse.position[0]
+    mouse_y = mouse.position[1]
+
+    for i, monitor in enumerate(get_monitors()):
+        if mouse_x >= monitor.x and mouse_x < monitor.x + monitor.width and mouse_y >= monitor.y and mouse_y < monitor.y + monitor.height:
+            return i
+    return 0
+
+
+def get_monitor(region, monitor_num, orientation, auto_adjust):
     """ Get info of where we want to map the tablet to
 
     Args:
@@ -20,6 +37,7 @@ def get_monitor(region, monitor_num, orientation):
         monitor_num (int): index of monitor to use.  Implies region=False
         orientation (str): Location of tablet charging port.
             ('top', 'bottom', 'left', 'right')
+        
 
     Returns:
         screeninfo.Monitor

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -97,6 +97,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
 
     x = y = 0
 
+    
     # loop inputs forever
     # for input_name, stream in cycle(rm_inputs.items()):
     stream = rm_inputs['pen']

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -76,7 +76,7 @@ def create_local_device():
     return device.create_uinput_device()
 
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative, monitor_update):
     """Pipe rM evdev events to local device
 
     Args:
@@ -102,11 +102,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     # for input_name, stream in cycle(rm_inputs.items()):
     stream = rm_inputs['pen']
     while True:
-        if auto_monitor:
-            new_monitor = get_current_monitor_num()
-            if new_monitor != monitor_num:
-                monitor_num = new_monitor
-                monitor, _ = get_monitor(region, monitor_num, orientation)
+        if auto_monitor and monitor_update[0] != monitor_num:
+            monitor_num=monitor_update[0]
+            monitor, _ = get_monitor(region, monitor_num, orientation)
 
         try:
             data = stream.read(16)

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -76,7 +76,7 @@ def create_local_device():
     return device.create_uinput_device()
 
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative, monitor_update):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, monitor_update):
     """Pipe rM evdev events to local device
 
     Args:
@@ -104,7 +104,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     while True:
         if auto_monitor and monitor_update[0] != monitor_num:
             monitor_num=monitor_update[0]
-            monitor, _ = get_monitor(region, monitor_num, orientation)
+            monitor, (tot_width, tot_height) = get_monitor(region, monitor_num, orientation)
 
         try:
             data = stream.read(16)

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -76,7 +76,7 @@ def create_local_device():
     return device.create_uinput_device()
 
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative):
     """Pipe rM evdev events to local device
 
     Args:
@@ -103,9 +103,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     while True:
         if auto_monitor:
             new_monitor = get_current_monitor_num()
-        if new_monitor != monitor_num:
-            monitor_num = new_monitor
-            monitor, _ = get_monitor(region, monitor_num, orientation)
+            if new_monitor != monitor_num:
+                monitor_num = new_monitor
+                monitor, _ = get_monitor(region, monitor_num, orientation)
 
         try:
             data = stream.read(16)

--- a/remarkable_mouse/evdev.py
+++ b/remarkable_mouse/evdev.py
@@ -8,7 +8,7 @@ from socket import timeout as TimeoutError
 import libevdev
 
 from .codes import codes, types
-from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event
+from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event, get_current_monitor_num
 
 logging.basicConfig(format='%(message)s')
 log = logging.getLogger('remouse')
@@ -76,7 +76,7 @@ def create_local_device():
     return device.create_uinput_device()
 
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor):
     """Pipe rM evdev events to local device
 
     Args:
@@ -101,6 +101,12 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
     # for input_name, stream in cycle(rm_inputs.items()):
     stream = rm_inputs['pen']
     while True:
+        if auto_monitor:
+            new_monitor = get_current_monitor_num()
+        if new_monitor != monitor_num:
+            monitor_num = new_monitor
+            monitor, _ = get_monitor(region, monitor_num, orientation)
+
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/pen.py
+++ b/remarkable_mouse/pen.py
@@ -15,11 +15,11 @@ log.debug('Using pen injection')
 
 # Constants
 
+# Max values for linux / windows 
 MAX_ABS_PRESSURE=4095
 MAX_WIN_PRESSURE=1024
 MAX_ANGLE=90
 MAX_ABS_TILT=6300
-
 
 # For penMask
 PEN_MASK_NONE=            0x00000000 # Default
@@ -119,7 +119,7 @@ def applyPen(x=0, y=0, pressure=0, tiltX=0, tiltY=0):
         pointerTypeInfo.penInfo.pointerInfo.pointerFlags = (POINTER_FLAG_DOWN if not currently_down else POINTER_FLAG_UPDATE | POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT)
         currently_down = True
     else:
-        pointerTypeInfo.penInfo.pointerInfo.pointerFlags = (POINTER_FLAG_UP if currently_down else POINTER_FLAG_UPDATE | POINTER_FLAG_INRANGE)
+        pointerTypeInfo.penInfo.pointerInfo.pointerFlags = (POINTER_FLAG_UP if currently_down==True else POINTER_FLAG_UPDATE | POINTER_FLAG_INRANGE)
         currently_down = False
 
     pointerTypeInfo.penInfo.pointerInfo.ptPixelLocation.x = x

--- a/remarkable_mouse/pen.py
+++ b/remarkable_mouse/pen.py
@@ -135,7 +135,7 @@ def applyPen(x=0, y=0, pressure=0, tiltX=0, tiltY=0):
         print(f"Error message: {ctypes.WinError(error_code).strerror}")
 
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative, monitor_update):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, monitor_update):
     """Loop forever and map evdev events to mouse
 
     Args:

--- a/remarkable_mouse/pen.py
+++ b/remarkable_mouse/pen.py
@@ -5,7 +5,7 @@ import time
 from screeninfo import get_monitors
 
 from .codes import codes, types
-from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event
+from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event, get_current_monitor_num
 from ctypes import *
 from ctypes.wintypes import *
 
@@ -136,7 +136,7 @@ def applyPen(x=0, y=0, pressure=0, tiltX=0, tiltY=0):
 
 
         
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -149,6 +149,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
         mode (str): mapping mode
     """
 
+
     monitor, _ = get_monitor(region, monitor_num, orientation)
     log.debug('Chose monitor: {}'.format(monitor))
 
@@ -157,6 +158,12 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
     stream = rm_inputs['pen']
 
     while True:
+        if auto_monitor:
+            new_monitor = get_current_monitor_num()
+        if new_monitor != monitor_num:
+            monitor_num = new_monitor
+            monitor, _ = get_monitor(region, monitor_num, orientation)
+
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/pen.py
+++ b/remarkable_mouse/pen.py
@@ -135,8 +135,7 @@ def applyPen(x=0, y=0, pressure=0, tiltX=0, tiltY=0):
         print(f"Error message: {ctypes.WinError(error_code).strerror}")
 
 
-        
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative, monitor_update):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -158,11 +157,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     stream = rm_inputs['pen']
 
     while True:
-        if auto_monitor:
-            new_monitor = get_current_monitor_num()
-            if new_monitor != monitor_num:
-                monitor_num = new_monitor
-                monitor, _ = get_monitor(region, monitor_num, orientation)
+        if auto_monitor and monitor_update[0] != monitor_num:
+            monitor_num=monitor_update[0]
+            monitor, _ = get_monitor(region, monitor_num, orientation)
 
         try:
             data = stream.read(16)

--- a/remarkable_mouse/pen.py
+++ b/remarkable_mouse/pen.py
@@ -1,0 +1,195 @@
+import logging
+import struct
+import ctypes
+from screeninfo import get_monitors
+
+from .codes import codes, types
+from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event
+from ctypes import *
+from ctypes.wintypes import *
+
+logging.basicConfig(format='%(message)s')
+log = logging.getLogger('remouse')
+log.debug('Using pen injection')
+
+# Constants
+# For penMask
+PEN_MASK_NONE=            0x00000000 # Default
+PEN_MASK_PRESSURE=        0x00000001
+PEN_MASK_ORIENTATION=     0x00000002
+PEN_MASK_TILT_X=          0x00000004
+PEN_MASK_TILT_Y=          0x00000008
+
+# For penFlag
+PEN_FLAG_NONE=            0x00000000
+
+# For pointerType
+PT_POINTER=               0x00000001 # All
+PT_TOUCH=                 0x00000002
+PT_PEN=                   0x00000003
+PT_MOUSE=                 0x00000004
+
+#For pointerFlags
+POINTER_FLAG_NONE=        0x00000000 # Default
+POINTER_FLAG_NEW=         0x00000001
+POINTER_FLAG_INRANGE=     0x00000002
+POINTER_FLAG_INCONTACT=   0x00000004
+POINTER_FLAG_FIRSTBUTTON= 0x00000010
+POINTER_FLAG_SECONDBUTTON=0x00000020
+POINTER_FLAG_THIRDBUTTON= 0x00000040
+POINTER_FLAG_FOURTHBUTTON=0x00000080
+POINTER_FLAG_FIFTHBUTTON= 0x00000100
+POINTER_FLAG_PRIMARY=     0x00002000
+POINTER_FLAG_CONFIDENCE=  0x00004000
+POINTER_FLAG_CANCELED=    0x00008000
+POINTER_FLAG_DOWN=        0x00010000
+POINTER_FLAG_UPDATE=      0x00020000
+POINTER_FLAG_UP=          0x00040000
+POINTER_FLAG_WHEEL=       0x00080000
+POINTER_FLAG_HWHEEL=      0x00100000
+POINTER_FLAG_CAPTURECHANGED=0x00200000
+
+# Structs Needed
+class POINTER_INFO(Structure):
+    _fields_=[("pointerType",c_uint32),
+              ("pointerId",c_uint32),
+              ("frameId",c_uint32),
+              ("pointerFlags",c_int),
+              ("sourceDevice",HANDLE),
+              ("hwndTarget",HWND),
+              ("ptPixelLocation",POINT),
+              ("ptHimetricLocation",POINT),
+              ("ptPixelLocationRaw",POINT),
+              ("ptHimetricLocationRaw",POINT),
+              ("dwTime",DWORD),
+              ("historyCount",c_uint32),
+              ("inputData",c_int32),
+              ("dwKeyStates",DWORD),
+              ("PerformanceCount",c_uint64),
+              ("ButtonChangeType",c_int)
+              ]
+              
+class POINTER_PEN_INFO(Structure):
+    _fields_=[("pointerInfo",POINTER_INFO),
+              ("penFlags",c_int),
+              ("penMask",c_int),
+              ("pressure", c_uint32),
+              ("rotation", c_uint32),
+              ("tiltX", c_int32),
+              ("tiltY", c_int32)]
+              
+class DUMMYUNIONNAME(Structure):
+   _fields_=[("penInfo",POINTER_PEN_INFO)
+              ]
+
+class POINTER_TYPE_INFO(Structure):
+   _fields_=[("type",c_uint32),
+              ("penInfo",POINTER_PEN_INFO)
+              ]
+
+# Initialize Pointer and Touch info
+pointerInfo = POINTER_INFO(pointerType=PT_PEN,
+                            pointerId=0,
+                            ptPixelLocation=POINT(950, 540),
+                            pointerFlags=POINTER_FLAG_NEW)
+penInfo = POINTER_PEN_INFO(pointerInfo=pointerInfo,
+                                penMask=(PEN_MASK_PRESSURE | PEN_MASK_TILT_X | PEN_MASK_TILT_Y),
+                                pressure=0,
+                                tiltX=0,
+                                tiltY=0)
+
+pointerTypeInfo = POINTER_TYPE_INFO(type=PT_PEN,
+                            penInfo=penInfo)
+
+device = windll.user32.CreateSyntheticPointerDevice(3, 1, 1)
+print("Initialized Pen Injection as number ", device)
+currently_down = False
+
+def updatePenInfo(down, x=0, y=0, pressure=0, tiltX=0, tiltY=0):
+    global currently_down
+    if down == True:
+        pointerTypeInfo.penInfo.pointerInfo.pointerFlags = (POINTER_FLAG_DOWN if not currently_down==True else POINTER_FLAG_UPDATE | POINTER_FLAG_INCONTACT)
+        currently_down = True
+    else:
+        pointerTypeInfo.penInfo.pointerInfo.pointerFlags = (POINTER_FLAG_UP if currently_down==True else POINTER_FLAG_UPDATE | POINTER_FLAG_INRANGE)
+        currently_down = False
+
+    pointerTypeInfo.penInfo.pointerInfo.ptPixelLocation.x = x
+    pointerTypeInfo.penInfo.pointerInfo.ptPixelLocation.y = y
+    pointerTypeInfo.penInfo.pressure = pressure
+    pointerTypeInfo.penInfo.tiltX = tiltX
+    pointerTypeInfo.penInfo.tiltY = tiltY
+
+def applyPen():
+    result = windll.user32.InjectSyntheticPointerInput(device, byref(pointerTypeInfo), 1)
+    if (result == False) and (log.level == logging.DEBUG):
+        error_code = ctypes.get_last_error()
+        print(f"Failed trying to update pen input. Error code: {error_code}")
+        print(f"Error message: {ctypes.WinError(error_code).strerror}")
+        
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode):
+    """Loop forever and map evdev events to mouse
+
+    Args:
+        rm_inputs (dictionary of paramiko.ChannelFile): dict of pen, button
+            and touch input streams
+        orientation (str): tablet orientation
+        monitor_num (int): monitor number to map to
+        region (boolean): whether to selection mapping region with region tool
+        threshold (int): pressure threshold
+        mode (str): mapping mode
+    """
+
+    monitor, _ = get_monitor(region, monitor_num, orientation)
+    log.debug('Chose monitor: {}'.format(monitor))
+
+    x = y = mapped_x = mapped_y = press = mapped_press = tiltX = tiltY = 0
+
+    stream = rm_inputs['pen']
+
+    while True:
+        try:
+            data = stream.read(16)
+        except TimeoutError:
+            continue
+
+        e_time, e_millis, e_type, e_code, e_value = struct.unpack('2IHHi', data)
+
+        # handle x direction
+        if codes[e_type][e_code] == 'ABS_X':
+            x = e_value
+
+        # handle y direction
+        if codes[e_type][e_code] == 'ABS_Y':
+            y = e_value
+            
+        # handle pressure
+        if codes[e_type][e_code] == 'ABS_PRESSURE':
+            press = e_value
+            mapped_press = int(press* (1024/4095))
+            
+        # handle tilt
+        if codes[e_type][e_code] == 'ABS_TILT_X':
+            tiltX = int(e_value*(90/6300))
+            
+        # handle pressure
+        if codes[e_type][e_code] == 'ABS_TILT_Y':
+            tiltY = int(e_value*(90/6300))
+
+        if codes[e_type][e_code] == 'SYN_REPORT':
+            mapped_x, mapped_y = remap(
+                x, y,
+                wacom_max_x, wacom_max_y,
+                monitor.width, monitor.height,
+                mode, orientation,
+            )
+            
+        # handle draw
+        if press > 0:
+            updatePenInfo(True, int(mapped_x), int(mapped_y), mapped_press, tiltX, tiltY)
+        else:
+            updatePenInfo(False, int(mapped_x), int(mapped_y), mapped_press, tiltX, tiltY)
+        applyPen()
+
+        # if log.level == logging.DEBUG:
+            # log_event(e_time, e_millis, e_type, e_code, e_value)

--- a/remarkable_mouse/pen.py
+++ b/remarkable_mouse/pen.py
@@ -136,7 +136,7 @@ def applyPen(x=0, y=0, pressure=0, tiltX=0, tiltY=0):
 
 
         
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -160,9 +160,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     while True:
         if auto_monitor:
             new_monitor = get_current_monitor_num()
-        if new_monitor != monitor_num:
-            monitor_num = new_monitor
-            monitor, _ = get_monitor(region, monitor_num, orientation)
+            if new_monitor != monitor_num:
+                monitor_num = new_monitor
+                monitor, _ = get_monitor(region, monitor_num, orientation)
 
         try:
             data = stream.read(16)

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -14,7 +14,7 @@ log = logging.getLogger('remouse')
 # finger_width = 767
 # finger_height = 1023
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor, relative):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -76,10 +76,16 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
                 monitor.width, monitor.height,
                 mode, orientation,
             )
-            mouse.move(
-                monitor.x + mapped_x - mouse.position[0],
-                monitor.y + mapped_y - mouse.position[1]
-            )
+            if relative:
+                mouse.move(
+                    monitor.x + mapped_x,
+                    monitor.y + mapped_y
+                )
+            else:
+                mouse.move(
+                    monitor.x + mapped_x - mouse.position[0],
+                    monitor.y + mapped_y - mouse.position[1]
+                )
 
         if log.level == logging.DEBUG:
             log_event(e_time, e_millis, e_type, e_code, e_value)

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -85,6 +85,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
                 if not in_range:
                     start_x = mapped_x
                     start_y = mapped_y
+                    in_range = True
                 mouse.move(
                     monitor.x + mapped_x - start_x - mouse.position[0],
                     monitor.y + mapped_y - start_y - mouse.position[1]

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -39,7 +39,7 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
 
     x = y = 0
 
-    in_range = False
+    in_range = True
     start_x = 0
     start_y = 0
 
@@ -87,8 +87,8 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
                     start_y = mapped_y
                     in_range = True
                 mouse.move(
-                    monitor.x + mapped_x - start_x - mouse.position[0],
-                    monitor.y + mapped_y - start_y - mouse.position[1]
+                    monitor.x + mapped_x - start_x,
+                    monitor.y + mapped_y - start_y
                 )
             else:
                 mouse.move(

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -4,7 +4,7 @@ from screeninfo import get_monitors
 
 # from .codes import EV_SYN, EV_ABS, ABS_X, ABS_Y, BTN_TOUCH
 from .codes import codes
-from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event
+from .common import get_monitor, remap, wacom_max_x, wacom_max_y, log_event, get_current_monitor_num
 
 logging.basicConfig(format='%(message)s')
 log = logging.getLogger('remouse')
@@ -14,7 +14,7 @@ log = logging.getLogger('remouse')
 # finger_width = 767
 # finger_height = 1023
 
-def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode):
+def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode, auto_monitor):
     """Loop forever and map evdev events to mouse
 
     Args:
@@ -25,11 +25,14 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
         region (boolean): whether to selection mapping region with region tool
         threshold (int): pressure threshold
         mode (str): mapping mode
+        auto_monitor (str)
     """
 
     from pynput.mouse import Button, Controller
 
     mouse = Controller()
+
+
 
     monitor, _ = get_monitor(region, monitor_num, orientation)
     log.debug('Chose monitor: {}'.format(monitor))
@@ -38,6 +41,12 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode)
 
     stream = rm_inputs['pen']
     while True:
+        if auto_monitor:
+            new_monitor = get_current_monitor_num()
+        if new_monitor != monitor_num:
+            monitor_num = new_monitor
+            monitor, _ = get_monitor(region, monitor_num, orientation)
+
         try:
             data = stream.read(16)
         except TimeoutError:

--- a/remarkable_mouse/pynput.py
+++ b/remarkable_mouse/pynput.py
@@ -43,9 +43,9 @@ def read_tablet(rm_inputs, *, orientation, monitor_num, region, threshold, mode,
     while True:
         if auto_monitor:
             new_monitor = get_current_monitor_num()
-        if new_monitor != monitor_num:
-            monitor_num = new_monitor
-            monitor, _ = get_monitor(region, monitor_num, orientation)
+            if new_monitor != monitor_num:
+                monitor_num = new_monitor
+                monitor, _ = get_monitor(region, monitor_num, orientation)
 
         try:
             data = stream.read(16)

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -142,6 +142,7 @@ def main():
         parser.add_argument('--threshold', metavar='THRESH', default=600, type=int, help="stylus pressure threshold (default 600)")
         parser.add_argument('--evdev', action='store_true', default=False, help="use evdev to support pen pressure (requires root, Linux only)")
         parser.add_argument('--pen', action='store_true', default=False, help="use pen input to support pen pressure in windows")
+        parser.add_argument('--auto-monitor', action='store_true', default=True, help="actively switch monitor to the one that the mouse is currently on")
 
         args = parser.parse_args()
 
@@ -171,6 +172,7 @@ def main():
         else:
             from remarkable_mouse.pynput import read_tablet
 
+
         read_tablet(
             rm_inputs,
             orientation=args.orientation,
@@ -178,6 +180,8 @@ def main():
             region=args.region,
             threshold=args.threshold,
             mode=args.mode,
+            auto_monitor=args.auto-monitor,
+
         )
 
     except PermissionError:

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -16,9 +16,6 @@ import paramiko.agent
 import paramiko.config
 import time
 
-LINUX = "Linux"
-WINDOWS = "Windows"
-
 
 logging.basicConfig(format='%(message)s')
 log = logging.getLogger('remouse')
@@ -26,6 +23,8 @@ log = logging.getLogger('remouse')
 default_key = os.path.expanduser('~/.ssh/remarkable')
 config_path = os.path.expanduser('~/.ssh/config')
 
+
+POLL_TIME = 0.2
 
 def open_rm_inputs(*, address, key, password):
     """
@@ -202,13 +201,12 @@ def main():
         th.start()
         
         # checking every time slows down pen movement too much
-        if automonitor:
-            while(True):
-                if args.automonitor:
-                    time.sleep(0.2)
-                    new_monitor = get_current_monitor_num()
-                    if new_monitor != monitor_num_obj[0]:
-                        monitor_num_obj[0] = new_monitor
+        while(True):
+            time.sleep(POLL_TIME)
+            if automonitor:
+                new_monitor = get_current_monitor_num()
+                if new_monitor != monitor_num_obj[0]:
+                    monitor_num_obj[0] = new_monitor
 
 
     except PermissionError:

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -141,6 +141,7 @@ def main():
         parser.add_argument('--region', action='store_true', default=False, help="Use a GUI to position the output area. Overrides --monitor")
         parser.add_argument('--threshold', metavar='THRESH', default=600, type=int, help="stylus pressure threshold (default 600)")
         parser.add_argument('--evdev', action='store_true', default=False, help="use evdev to support pen pressure (requires root, Linux only)")
+        parser.add_argument('--pen', action='store_true', default=False, help="use pen input to support pen pressure in windows")
 
         args = parser.parse_args()
 
@@ -163,6 +164,9 @@ def main():
 
         if args.evdev:
             from remarkable_mouse.evdev import read_tablet
+
+        elif args.pen:
+            from remarkable_mouse.pen import read_tablet
 
         else:
             from remarkable_mouse.pynput import read_tablet

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -202,16 +202,21 @@ def main():
                 'auto_monitor':args.automonitor, 
                 'relative':args.relative,
                 'monitor_update': monitor_num_obj
-                })
+                }, 
+                daemon=True)
         th.start()
         
         # checking every time slows down pen movement too much
-        if args.automonitor:
+
+        try:
             while(True):
-                time.sleep(0.2)
-                new_monitor = get_current_monitor_num()
-                if new_monitor != monitor_num_obj[0]:
-                    monitor_num_obj[0] = new_monitor
+                if args.automonitor:
+                    time.sleep(0.2)
+                    new_monitor = get_current_monitor_num()
+                    if new_monitor != monitor_num_obj[0]:
+                        monitor_num_obj[0] = new_monitor
+        except KeyboardInterrupt:
+            pass
 
 
     except PermissionError:

--- a/remarkable_mouse/remarkable_mouse.py
+++ b/remarkable_mouse/remarkable_mouse.py
@@ -142,7 +142,7 @@ def main():
         parser.add_argument('--threshold', metavar='THRESH', default=600, type=int, help="stylus pressure threshold (default 600)")
         parser.add_argument('--evdev', action='store_true', default=False, help="use evdev to support pen pressure (requires root, Linux only)")
         parser.add_argument('--pen', action='store_true', default=False, help="use pen input to support pen pressure in windows")
-        parser.add_argument('--auto-monitor', action='store_true', default=True, help="actively switch monitor to the one that the mouse is currently on")
+        parser.add_argument('--auto-monitor', action='store_true', default=False, help="actively switch monitor to the one that the mouse is currently on. Overrides --monitor and --region")
 
         args = parser.parse_args()
 
@@ -172,6 +172,7 @@ def main():
         else:
             from remarkable_mouse.pynput import read_tablet
 
+        
 
         read_tablet(
             rm_inputs,
@@ -180,7 +181,7 @@ def main():
             region=args.region,
             threshold=args.threshold,
             mode=args.mode,
-            auto_monitor=args.auto-monitor,
+            auto_monitor=args["auto-monitor"],
 
         )
 


### PR DESCRIPTION
Builds upon @DCS-87's implementation of pressure sensing on Windows. 

Dynamically changes the monitor to output to based on mouse position. This is now on by default and is overridden when the `--monitor`  or `--region` tags are used.

I think these changes are significant enough to be worth publishing a new version to PyPi!